### PR TITLE
Last mongo is not working with me let's use mongo:4

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ app:
     - db:db
 
 db:
-  image: mongo
+  image: mongo:4
 
 tests:
   image: 192.168.60.200:5000/books-ms-tests


### PR DESCRIPTION
- Make it working for me
- Fix WARNING: MongoDB 5.0+ requires a CPU with AVX support
- github.com[0:]: errno=Connection timed out
- fix with mongo 4 version
